### PR TITLE
Close #15 Name location in notification if changed

### DIFF
--- a/app/views/notifications/_update_of_meeting.html.erb
+++ b/app/views/notifications/_update_of_meeting.html.erb
@@ -2,6 +2,7 @@
 <%-
   translation = {
     :address => "Ort",
+    :adress_attributes => "Ort",
     :starts_at_date => "Datum",
     :ends_at_date => "Datum",
     :starts_at_time => "Uhrzeit",


### PR DESCRIPTION
The address poses an edge case since it is not a trivial attribute of a meeting.
We want to inform the user if the address of the meeting changed, but so far
we only considered attriubutes of the meeting. However, if the street of the
address, which belongs to the meeting, changes the
Meeting#changed_attributes will not include the
attributes of the related address. Therefore we merge them and pass it to
the PublicActivity:Activity#parameters attributes in a single hash.