### PR TITLE
Close #104 Do not display notification created before enabled

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,7 +63,7 @@ class User < ActiveRecord::Base
   end
 
   def website_notifications
-    notifications.where(["bitmask & ? > 0", enabled_website_notifications])
+    notifications.where(["bitmask & ? > 0", enabled_website_notifications]).where(display_on_website: true)
   end
 
   def mail_notifications(interval)

--- a/db/migrate/20150917184748_add_display_website_to_notifications.rb
+++ b/db/migrate/20150917184748_add_display_website_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddDisplayWebsiteToNotifications < ActiveRecord::Migration
+  def change
+    add_column :notifications, :display_on_website, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150916224938) do
+ActiveRecord::Schema.define(version: 20150917184748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -219,7 +219,8 @@ ActiveRecord::Schema.define(version: 20150916224938) do
     t.boolean  "seen",        default: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "sent",        default: false
+    t.boolean  "sent",               default: false
+    t.boolean  "display_on_website", default: false
   end
 
   create_table "posts", force: :cascade do |t|

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe NotificationsController, type: :controller do
       before do
         stub_const("NotificationsController::NOTIFICATIONS_PER_PAGE", 3)
         (NotificationsController::NOTIFICATIONS_PER_PAGE + 3).times do
-          create(:notification, user: user) 
+          create(:notification, user: user, display_on_website: true) 
         end
 
         sign_in user

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -335,4 +335,18 @@ RSpec.describe Notification, type: :model do
       end
     end
   end 
+  
+  context "a website notification type is enabled after notification creation" do
+    let(:user) { create(:user, graetzl: meeting.graetzl) }
+
+    it "does not create a notification record" do
+      expect(user.enabled_website_notification?(:new_meeting_in_graetzl)).to be_falsy
+      expect(user.website_notifications.to_a).to be_empty
+      meeting.create_activity :create, owner: create(:user)
+      expect(user.website_notifications.to_a).to be_empty
+      user.enable_website_notification(:new_meeting_in_graetzl)
+      user.notifications.reload
+      expect(user.website_notifications.to_a).to be_empty
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe User, type: :model do
     before do
       Notification::TYPES.keys.each do |type|
         bitmask = Notification::TYPES[type][:bitmask]
-        create(:notification, user: user, bitmask: bitmask)
+        create(:notification, user: user, bitmask: bitmask, display_on_website: true)
       end
     end
 


### PR DESCRIPTION
If a notification was created before the user set the website_notification
to enabled, then don't display it. Only new notifications will enter
the notification center.